### PR TITLE
vfs_gluster: glfs_clear_preopened: fix leaked elements

### DIFF
--- a/src/vfs_glusterfs.c
+++ b/src/vfs_glusterfs.c
@@ -144,6 +144,9 @@ static void glfs_clear_preopened(glfs_t *fs)
 			DLIST_REMOVE(glfs_preopened, entry);
 
 			glfs_fini(entry->fs);
+			
+			talloc_free(entry->connectpath);
+			talloc_free(entry->volume);
 			talloc_free(entry);
 		}
 	}


### PR DESCRIPTION
It is glfs_clear_preopened() responsibility to clean memory allocated in
glfs_set_preopened()

Signed-off-by: Prasanna Kumar Kalever prasanna.kalever@redhat.com
